### PR TITLE
Docs: add testing instructions for backend and frontend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend (pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      PYTHONPATH: ${{ github.workspace }}/backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install deps
+        run: uv sync --dev
+
+      - name: Install pytest
+        run: uv pip install pytest
+
+      - name: Run tests
+        run: uv run python -m pytest
+
+  frontend:
+    name: Frontend (vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Enable corepack (yarn)
+        run: corepack enable
+
+      - name: Install deps
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test --run

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,9 @@ A Django application for accessibility tagging.
 Before getting started, ensure you have the following tools installed:
 
 - [uv](https://github.com/astral-sh/uv) - Python package and project manager
+  - Install: https://docs.astral.sh/uv/ (or `pip install uv` for basic usage)
 - [Docker](https://www.docker.com/) - For containerized deployment
+- Node.js / npm (for the frontend)
 
 ## Getting Started
 
@@ -21,6 +23,20 @@ make install
 ```
 
 ### Development
+
+#### Frontend (React)
+
+The UI is in the `frontend/` directory and runs separately during development.
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend runs on http://localhost:8080 by default.
+
+#### Backend (Django)
 
 Run the Django development server:
 ```bash
@@ -41,6 +57,32 @@ Access the Django shell:
 ```bash
 make shell
 ```
+
+## API Proxy Configuration (Important)
+
+The frontend uses a Vite proxy for `/api` requests (configured in
+`frontend/vite.config.ts`).
+
+By default, the proxy target is:
+```ts
+target: 'http://localhost:3000'
+```
+
+If you are running the Django development server locally (default port **8000**),
+you must either:
+
+- Update the proxy target to:
+  ```ts
+  target: 'http://localhost:8000'
+  ```
+- OR run the backend on port 3000 to match the existing proxy configuration.
+
+## Troubleshooting
+
+- **Upload error: `Unexpected end of JSON input`**  
+  This usually indicates a mismatch between the frontend `/api` proxy target
+  and the backend server port, or that the backend returned a non-JSON error response.
+
 
 ### Docker
 


### PR DESCRIPTION
Adds documentation describing how to run backend and frontend tests.
This improves onboarding for new contributors and clarifies how to
validate the existing test suite.
