### PR TITLE
Tests: add validator edge case and fix encrypted PDF stub

### DIFF
--- a/backend/tests/unit/test_extractor_extra.py
+++ b/backend/tests/unit/test_extractor_extra.py
@@ -82,6 +82,7 @@ def test_extract_accessibility_info_encrypted_and_password_error(monkeypatch, tm
     # Encrypted pdf early-return
     class EncryptedPdf:
         is_encrypted = True
+        pdf_version = "1.7"
 
         def __init__(self):
             self.pages = []

--- a/backend/tests/unit/test_extractor_extra.py
+++ b/backend/tests/unit/test_extractor_extra.py
@@ -107,3 +107,23 @@ def test_extract_accessibility_info_encrypted_and_password_error(monkeypatch, tm
     res2 = extractor.extract_accessibility_info(str(f), "enc.pdf")
     assert res2.is_encrypted is True
     assert any("password" in e.lower() for e in res2.errors)
+
+
+def test_extract_accessibility_info_corrupt_pdf(monkeypatch, tmp_path):
+    # Simulate pikepdf failing to open a corrupt PDF
+    def raise_corrupt(path):
+        raise Exception("corrupt pdf")
+
+    monkeypatch.setattr(extractor.pikepdf.Pdf, "open", raise_corrupt, raising=False)
+    monkeypatch.setattr(extractor.os.path, "getsize", lambda p: 1024)
+
+    f = tmp_path / "corrupt.pdf"
+    f.write_bytes(b"x")
+
+    res = extractor.extract_accessibility_info(str(f), "corrupt.pdf")
+
+    # ExtractionResult doesn't have can_proceed; validate via errors
+    assert res.is_encrypted is False
+    assert res.errors
+    assert any("unexpected" in e.lower() or "error" in e.lower() or "corrupt" in e.lower() for e in res.errors)
+

--- a/backend/tests/unit/test_validators_extra.py
+++ b/backend/tests/unit/test_validators_extra.py
@@ -44,3 +44,13 @@ def test_validate_pdf_file_very_large_warns(monkeypatch, tmp_path):
     assert any("Very large file" in w for w in res.warnings)
     assert any("Large file" in w for w in res.warnings)
     assert res.status == validators.ValidationStatus.WARNING.value
+
+def test_validate_pdf_file_rejects_non_pdf_extension(tmp_path):
+    f = tmp_path / "not_a_pdf.txt"
+    f.write_bytes(b"hello")
+
+    res = validators.validate_pdf_file(str(f))
+
+    assert res.can_proceed is False
+    assert res.status == validators.ValidationStatus.INVALID.value
+    assert any("pdf" in e.lower() for e in res.errors)


### PR DESCRIPTION
Adds an edge-case unit test for tag validation and fixes a failing
extractor test by updating the encrypted PDF mock to include expected
attributes.

Also adds coverage for corrupt PDF open failures to ensure graceful error handling.